### PR TITLE
Added "features" command to commands.json

### DIFF
--- a/src/commands.json
+++ b/src/commands.json
@@ -34,7 +34,7 @@
     "description": "Links to our tracking issue on platform support.",
     "args": 0
   },
-  "feature": {
+  "features": {
     "title": "{lookup}",
     "titleLookup": {
       "3ds": "3DS Screen Modes",

--- a/src/commands.json
+++ b/src/commands.json
@@ -34,6 +34,28 @@
     "description": "Links to our tracking issue on platform support.",
     "args": 0
   },
+  "feature": {
+    "title": "{lookup}",
+    "titleLookup": {
+      "3ds": "3DS Screen Modes",
+      "wii u": "Wii U Screen Modes",
+      "wii": "No Special Features",
+      "gamecube": "No Special Features",
+      "switch": "No Special Features",
+      "vita": "No Special Features",
+    },
+    "type": "lookup",
+    "body": {
+      "3ds": "Resolution 400x480 enables both screens. 400x240 and 320x240 display to top and bottom screens respectively.",
+      "wii u": "Displaying across the TV and Gamepad are currently unsupported",
+      "wii": "There are currently no special features for this platform",
+      "gamecube": "There are currently no special features for this platform",
+      "switch": "There are currently no special features for this platform",
+      "vita": "There are currently no special features for this platform",
+    },
+    "description": "Provides special features for given platforms.",
+    "args": 1
+  },
   "limitations": {
     "title": "Limitations",
     "type": "text",


### PR DESCRIPTION
Added a command that prints special features for each platform that SE! supports. Currently only prints unique results for 3DS displaying screen resolution and clarifies that Wii U dual screen displaying is currently unsupported.