### PR TITLE
feat: make `controls` show the requested platform's controls

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "scratch-everywhere-bot",

--- a/src/commands.json
+++ b/src/commands.json
@@ -23,9 +23,9 @@
   "controls": {
     "title": "Controls",
     "type": "image",
-    "body": "https://github.com/ScratchEverywhere/ScratchEverywhere/blob/main/docs/controls.png?raw=true",
-    "description": "Shows an image of the controls.",
-    "args": 0
+    "body": "https://github.com/ScratchEverywhere/ScratchEverywhere/blob/main/docs/controls/{arg0}.png?raw=true",
+    "description": "Shows an image of the controls for each platform.",
+    "args": 1
   },
   "platforms": {
     "title": "Platform Support",

--- a/src/index.ts
+++ b/src/index.ts
@@ -93,7 +93,12 @@ client.on("messageCreate", async (message: Message) => {
           );
           break;
         case "image":
-          embed.setImage(command.body as string);
+          embed.setImage(
+            args.reduce(
+              (body, arg, i) => body.replaceAll(`{arg${i}}`, arg),
+              command.body as string,
+            ),
+          );
           break;
         case "lookup":
           if (command.args != 1) {


### PR DESCRIPTION
Requires splitting the SE! control image into one image for each platform (done in a PR to the main repo that I will be making shortly).